### PR TITLE
Prepare for new version of lmerTest

### DIFF
--- a/R/Examp2.5.2.1.R
+++ b/R/Examp2.5.2.1.R
@@ -26,12 +26,12 @@
 #'  # RANDOM region drug*region;
 #'  # LSMEANS drug*dose;
 #'  # RUN;
-#'  
-#' library(lme4)
+#'
+#' library(lmerTest)
 #' str(ex125)
-#' 
-#' fm2.10 <- 
-#'   lme4::lmer(
+#'
+#' fm2.10 <-
+#'   lmerTest::lmer(
 #'          formula    = Pcv ~ dose*Drug + (1|Region/Drug)
 #'        , data       = ex125
 #'        , REML       = TRUE
@@ -45,10 +45,9 @@
 #'        , contrasts  = list(dose = "contr.SAS", Drug = "contr.SAS")
 #'        , devFunOnly = FALSE
 #'     #  , ...
-#'        )                       
+#'        )
 #' summary(fm2.10)
 #' anova(fm2.10)
 #' summary(fm2.10)$vcov
-#' library(lmerTest)  
-#' lmerTest::lsmeansLT(model = fm2.10, test.effs="dose:Drug")
+#' lsmeansLT(model = fm2.10)
 NULL

--- a/R/Examp2.5.3.1.R
+++ b/R/Examp2.5.3.1.R
@@ -25,8 +25,8 @@
 #'  # MODEL pcv=region drug region*drug dose drug*dose;
 #'  # RANDOM region drug*region;
 #'  # RUN;
-#'  
-#'  
+#'
+#'
 #'  # PROC MIXED DATA=ex125;
 #'  # CLASS drug dose region;
 #'  # MODEL pcv=drug dose drug*dose / ddfm=satterth;
@@ -38,11 +38,11 @@
 #'  # ESTIMATE 'Samorin high' INTERCEPT 1 drug 0 1 dose 1 0
 #'  #                             drug*dose 0 0 1 0;
 #'  # RUN;
-#'  
+#'
 #' library(lme4)
 #' str(ex125)
 #' ex125$Region1 <- factor(ex125$Region)
-#'  fm2.11 <- 
+#'  fm2.11 <-
 #'   aov(
 #'       formula     = Pcv ~ Region1 + Drug + Error(Drug:Region1) + dose + dose:Drug
 #'     , data        = ex125
@@ -52,8 +52,8 @@
 #'   #  , ...
 #'     )
 #'  summary(fm2.11)
-#' 
-#'  fm2.12 <- 
+#'
+#'  fm2.12 <-
 #'   lmerTest::lmer(
 #'          formula    = Pcv ~ dose*Drug + (1|Region/Drug)
 #'        , data       = ex125
@@ -68,10 +68,10 @@
 #'        , contrasts  = list(dose = "contr.SAS", Drug = "contr.SAS")
 #'        , devFunOnly = FALSE
 #'     #  , ...
-#'        )                       
+#'        )
 #'  summary(fm2.12)
-#'  lmerTest::anova(object = fm2.12, ddf = "Satterthwaite")
-#' 
+#'  anova(object = fm2.12, ddf = "Satterthwaite")
+#'
 #' library(multcomp)
 #' Contrasts1 <-
 #'           matrix(c(
@@ -87,8 +87,8 @@
 #'                 , rownames(summary(fm2.12)$coef)
 #'                )
 #'               )
-#' 
+#'
 #' Contrasts1
 #' summary(glht(fm2.12, linfct=Contrasts1))
-#' 
+#'
 NULL

--- a/R/Examp2.6.1.R
+++ b/R/Examp2.6.1.R
@@ -29,11 +29,11 @@
 #'  #                drug 0  0 dose 1 -1 drug*dose 0.5 -0.5  0.5 -0.5,
 #'  #                drug 0  0 dose 0  0 drug*dose 0.5 -0.5 -0.5  0.5;
 #'  # RUN;
-#'  
-#'  library(lme4)
+#'
+#'  library(lmerTest)
 #'  str(ex125)
 #'  ex125$Region1 <- factor(ex125$Region)
-#'  fm2.14 <- 
+#'  fm2.14 <-
 #'   lmerTest::lmer(
 #'          formula    = Pcv ~ dose*Drug + (1|Region/Drug)
 #'        , data       = ex125
@@ -48,10 +48,10 @@
 #'        , contrasts  = list(dose = "contr.SAS", Drug = "contr.SAS")
 #'        , devFunOnly = FALSE
 #'     #  , ...
-#'        )                       
+#'        )
 #'  summary(fm2.14)
-#'  lmerTest::anova(object = fm2.14, ddf = "Satterthwaite")
-#'  
+#'  anova(object = fm2.14, ddf = "Satterthwaite")
+#'
 #'  library(multcomp)
 #'  Contrasts3 <-
 #'            matrix(c(
@@ -64,8 +64,11 @@
 #'                  , rownames(summary(fm2.14)$coef)
 #'                 )
 #'                )
-#'  
+#'
 #'  Contrasts3
 #'  summary(glht(fm2.14, linfct=Contrasts3))
-#'  
+#'
+#' if(packageVersion("lmerTest") >= "3.0")
+#'    contest(fm2.14, Contrasts3, joint = FALSE)
+#'
 NULL

--- a/R/Examp3.1.R
+++ b/R/Examp3.1.R
@@ -30,17 +30,17 @@
 #' # CONTRAST 'Berenil dif 2 doses' dose(drug) 1 -1 0;
 #' # CONTRAST 'Ber vs Sam at dose 1' drug 1 -1 dose(drug) 1 0 -l;
 #' # CONTRAST 'some difference' drug 1 -1 dose(drug) 0.5 0.5 -1,
-#' #           drug 0 0 dose(drug) 1 -1 0; 
+#' #           drug 0 0 dose(drug) 1 -1 0;
 #' # LSMEANS dose(drug);
 #' # RUN;
-#'  
+#'
 #'  library(lmerTest)
 #'  str(ex31)
 #'  ex31$drug1 <- factor(ex31$drug)
 #'  ex31$dose1 <- factor(ex31$dose)
 #'  ex31$herd1 <- factor(ex31$herd)
-#'  
-#'  fm3.1 <- 
+#'
+#'  fm3.1 <-
 #'   lmerTest::lmer(
 #'          formula    = PCV2 ~ drug1 + dose1:drug1 + (1|herd1:drug1)
 #'        , data       = ex31
@@ -55,11 +55,11 @@
 #'        , contrasts  = list(dose1 = "contr.SAS", drug1 = "contr.SAS")
 #'        , devFunOnly = FALSE
 #'     #  , ...
-#'        )                       
+#'        )
 #'  summary(fm3.1)
-#'  lmerTest::anova(object = fm3.1, ddf = "Satterthwaite")
-#'  lmerTest::lsmeansLT(model = fm3.1, test.effs = "dose1:drug1")
-#'  
+#'  anova(object = fm3.1, ddf = "Satterthwaite")
+#'  lsmeansLT(model = fm3.1, test.effs = "dose1:drug1")
+#'
 #' #-------------------------------------------------------------
 #' ## Example 3.1 Model 2 p-84
 #' #-------------------------------------------------------------
@@ -68,14 +68,14 @@
 #' # MODEL PCV2=PCV1 drug dose(drug)/solution ddfm=satterth;
 #' # RANDOM herd(drug);
 #' # RUN;
-#'  
+#'
 #'  library(lmerTest)
 #'  str(ex31)
 #'  ex31$drug1 <- factor(ex31$drug)
 #'  ex31$dose1 <- factor(ex31$dose)
 #'  ex31$herd1 <- factor(ex31$herd)
-#'  
-#'  fm3.2 <- 
+#'
+#'  fm3.2 <-
 #'   lmerTest::lmer(
 #'          formula    = PCV2 ~ PCV1 + drug1 + dose1:drug1 + (1|herd1:drug1)
 #'        , data       = ex31
@@ -90,11 +90,11 @@
 #'        , contrasts  = list(dose1 = "contr.SAS", drug1 = "contr.SAS")
 #'        , devFunOnly = FALSE
 #'     #  , ...
-#'        )                       
+#'        )
 #'  summary(fm3.2)
-#'  lmerTest::anova(object = fm3.2, ddf = "Satterthwaite")
-#'  lmerTest::lsmeansLT(model = fm3.2, test.effs = "herd1:drug1")
-#'  
+#'  anova(object = fm3.2, ddf = "Satterthwaite")
+#'  lsmeansLT(model = fm3.2, test.effs = "herd1:drug1")
+#'
 #' #-------------------------------------------------------------
 #' ## Example 3.1 Model 3 p-86
 #' #-------------------------------------------------------------
@@ -103,14 +103,14 @@
 #' # MODEL PCV2=drug dose(drug) PCV1*dose(drug)/solution ddfm=satterth;
 #' # RANDOM herd(drug);
 #' # RUN;
-#'  
+#'
 #'  library(lmerTest)
 #'  str(ex31)
 #'  ex31$drug1 <- factor(ex31$drug)
 #'  ex31$dose1 <- factor(ex31$dose)
 #'  ex31$herd1 <- factor(ex31$herd)
-#'  
-#'  fm3.3 <- 
+#'
+#'  fm3.3 <-
 #'   lmerTest::lmer(
 #'          formula    = PCV2 ~ drug1 + PCV1*dose1:drug1 + (1|herd1:drug1)
 #'        , data       = ex31
@@ -125,8 +125,8 @@
 #'        , contrasts  = list(dose1 = "contr.SAS", drug1 = "contr.SAS")
 #'        , devFunOnly = FALSE
 #'     #  , ...
-#'        )                       
+#'        )
 #'  summary(fm3.3)
-#'  lmerTest::anova(object = fm3.3, ddf = "Satterthwaite")
-#'  lmerTest::lsmeansLT(model = fm3.3, test.effs = "dose1:drug1")
+#'  anova(object = fm3.3, ddf = "Satterthwaite")
+#'  lsmeansLT(model = fm3.3, test.effs = "dose1:drug1")
 NULL

--- a/R/Examp3.2.R
+++ b/R/Examp3.2.R
@@ -26,13 +26,13 @@
 #' # RANDOM sire_id(breed)/SOLUTION;
 #' # LSMEANS breed/ADJUST = TUKEY;
 #' # RUN;
-#'  
+#'
 #'  library(lmerTest)
 #'  str(ex32)
 #'  ex32$sire_id1 <- factor(ex32$sire_id)
 #'  ex32$breed1   <- factor(ex32$breed)
-#'  
-#'  fm3.4 <- 
+#'
+#'  fm3.4 <-
 #'   lmerTest::lmer(
 #'          formula    = Ww ~ sex + agew + breed1 + (1|sire_id1:breed1)
 #'        , data       = ex32
@@ -47,8 +47,8 @@
 #'        , contrasts  = list(sex = "contr.SAS", breed1 = "contr.SAS")
 #'        , devFunOnly = FALSE
 #'     #  , ...
-#'        )                       
+#'        )
 #'  summary(fm3.4)
-#'  lmerTest::anova(object = fm3.4, ddf = "Satterthwaite")
-#'  lmerTest::lsmeansLT(model = fm3.4, test.effs = "breed1")
+#'  anova(object = fm3.4, ddf = "Satterthwaite")
+#'  lsmeansLT(model = fm3.4)
 NULL

--- a/R/Examp3.3.R
+++ b/R/Examp3.3.R
@@ -25,12 +25,12 @@
 #' # MODEL pcv = breed breed*time/SOLUTION;
 #' # RANDOM animal_id(breed)/SOLUTION;
 #' # RUN;
-#' 
+#'
 #'  library(lme4)
 #'  options(contrasts = c(factor = "contr.SAS", ordered = "contr.poly"))
 #'  str(ex33)
-#'    
-#'  fm3.5 <- 
+#'
+#'  fm3.5 <-
 #'   lme4::lmer(
 #'          formula    = PCV ~ breed + breed:time + (1|animal_id:breed)
 #'        , data       = ex33
@@ -45,12 +45,12 @@
 #'        , contrasts  = list(breed = "contr.SAS")
 #'        , devFunOnly = FALSE
 #'     #  , ...
-#'        )                       
+#'        )
 #'  summary(fm3.5)
 #'  anova(fm3.5)
-#'  
-#'  
-#'  fm3.6 <- 
+#'
+#'  library(lmerTest)
+#'  fm3.6 <-
 #'   lmerTest::lmer(
 #'          formula    = PCV ~ breed + breed:time + (1|animal_id:breed)
 #'        , data       = ex33
@@ -65,20 +65,20 @@
 #'        , contrasts  = list(breed = "contr.SAS")
 #'        , devFunOnly = FALSE
 #'     #  , ...
-#'        )                       
+#'        )
 #'  summary(fm3.6)
-#'  lmerTest::anova(object = fm3.6, ddf = "Satterthwaite")
+#'  anova(object = fm3.6, ddf = "Satterthwaite")
 #'
-#' 
+#'
 #' # PROC MIXED DATA=ex33;
 #' # CLASS breed animal_id;
 #' # MODEL pcv = breed breed*time/SOLUTION;
 #' # REPEATED/TYPE=CS SUB = animal_id(breed) R;
 #' # RUN;
-#' 
 #'
-#'  library(nlme)  
-#'  fm3.7 <- 
+#'
+#'  library(nlme)
+#'  fm3.7 <-
 #'       nlme::gls(
 #'             model       = PCV ~ breed + breed:time
 #'           , data        = ex33
@@ -86,21 +86,21 @@
 #'           , weights     = NULL
 #'         # , subset      =
 #'           , method      = "REML" # c("REML", "ML")
-#'           , na.action   = na.fail 
+#'           , na.action   = na.fail
 #'           , control     = list()
 #'           )
 #'  summary(fm3.7)
 #'  anova(fm3.7)
-#'  
-#'  
-#'  
+#'
+#'
+#'
 #' # PROC MIXED DATA=ex33;
 #' # CLASS breed animal_id;
 #' # MODEL pcv = time breed breed*time/SOLUTION;
 #' # RANDOM animal_id(breed)/SOLUTION;
 #' # RUN;
-#'      
-#'  fm3.8 <- 
+#'
+#'  fm3.8 <-
 #'   lme4::lmer(
 #'          formula    = PCV ~ time + breed + breed:time + (1|animal_id:breed)
 #'        , data       = ex33
@@ -119,8 +119,8 @@
 #'  summary(fm3.8)
 #'  anova(fm3.8)
 #'
-#'    
-#'  fm3.9 <- 
+#'
+#'  fm3.9 <-
 #'   lmerTest::lmer(
 #'          formula    = PCV ~ time + breed + breed:time + (1|animal_id:breed)
 #'        , data       = ex33
@@ -137,18 +137,18 @@
 #'     #  , ...
 #'        )
 #'  summary(fm3.9)
-#'  lmerTest::anova(object = fm3.9, ddf = "Satterthwaite", type = 3)
-#'  
-#'  
+#'  anova(object = fm3.9, ddf = "Satterthwaite", type = 3)
+#'
+#'
 #' # PROC MIXED DATA=ex33;
 #' # CLASS breed animal_id;
 #' # MODEL pcv = breed breed*time/SOLUTION;
 #' # REPEATED/TYPE=AR(1) SUBJET = animal_id(breed) R;
 #' # RUN;
-#' 
 #'
-#'  library(nlme)  
-#'  fm3.10 <- 
+#'
+#'  library(nlme)
+#'  fm3.10 <-
 #'       nlme::gls(
 #'             model       = PCV ~ breed + breed:time
 #'           , data        = ex33
@@ -156,7 +156,7 @@
 #'           , weights     = NULL
 #'         # , subset      =
 #'           , method      = "REML" # c("REML", "ML")
-#'           , na.action   = na.fail 
+#'           , na.action   = na.fail
 #'           , control     = list()
 #'           )
 #'  summary(fm3.10)
@@ -167,10 +167,10 @@
 #' # MODEL pcv = breed breed*time/SOLUTION;
 #' # RANDOM INTERCEPT time/TYPE=UN SUBJET = animal_id(breed) SOLUTION;
 #' # RUN;
-#' 
+#'
 #'
 #'  library(nlme)
-#' # fm3.11 <- 
+#' # fm3.11 <-
 #' #      nlme::gls(
 #' #            model       = PCV ~ breed + breed:time
 #' #          , data        = ex33
@@ -179,10 +179,10 @@
 #' #          , weights     = NULL
 #' #        # , subset      =
 #' #          , method      = "REML" # c("REML", "ML")
-#' #          , na.action   = na.fail 
+#' #          , na.action   = na.fail
 #' #          , control     = list()
 #' #          )
 #' # summary(fm3.11)
 #' # anova(fm3.11)
-#'       
+#'
 NULL

--- a/man/Examp2.5.2.1.Rd
+++ b/man/Examp2.5.2.1.Rd
@@ -18,12 +18,12 @@ linear models and generalized linear models.
  # RANDOM region drug*region;
  # LSMEANS drug*dose;
  # RUN;
- 
-library(lme4)
+
+library(lmerTest)
 str(ex125)
 
-fm2.10 <- 
-  lme4::lmer(
+fm2.10 <-
+  lmerTest::lmer(
          formula    = Pcv ~ dose*Drug + (1|Region/Drug)
        , data       = ex125
        , REML       = TRUE
@@ -37,12 +37,11 @@ fm2.10 <-
        , contrasts  = list(dose = "contr.SAS", Drug = "contr.SAS")
        , devFunOnly = FALSE
     #  , ...
-       )                       
+       )
 summary(fm2.10)
 anova(fm2.10)
 summary(fm2.10)$vcov
-library(lmerTest)  
-lmerTest::lsmeansLT(model = fm2.10, test.effs="dose:Drug")
+lsmeansLT(model = fm2.10)
 }
 \references{
 \enumerate{

--- a/man/Examp2.5.3.1.Rd
+++ b/man/Examp2.5.3.1.Rd
@@ -17,8 +17,8 @@ linear models and generalized linear models.
  # MODEL pcv=region drug region*drug dose drug*dose;
  # RANDOM region drug*region;
  # RUN;
- 
- 
+
+
  # PROC MIXED DATA=ex125;
  # CLASS drug dose region;
  # MODEL pcv=drug dose drug*dose / ddfm=satterth;
@@ -30,11 +30,11 @@ linear models and generalized linear models.
  # ESTIMATE 'Samorin high' INTERCEPT 1 drug 0 1 dose 1 0
  #                             drug*dose 0 0 1 0;
  # RUN;
- 
+
 library(lme4)
 str(ex125)
 ex125$Region1 <- factor(ex125$Region)
- fm2.11 <- 
+ fm2.11 <-
   aov(
       formula     = Pcv ~ Region1 + Drug + Error(Drug:Region1) + dose + dose:Drug
     , data        = ex125
@@ -45,7 +45,7 @@ ex125$Region1 <- factor(ex125$Region)
     )
  summary(fm2.11)
 
- fm2.12 <- 
+ fm2.12 <-
   lmerTest::lmer(
          formula    = Pcv ~ dose*Drug + (1|Region/Drug)
        , data       = ex125
@@ -60,9 +60,9 @@ ex125$Region1 <- factor(ex125$Region)
        , contrasts  = list(dose = "contr.SAS", Drug = "contr.SAS")
        , devFunOnly = FALSE
     #  , ...
-       )                       
+       )
  summary(fm2.12)
- lmerTest::anova(object = fm2.12, ddf = "Satterthwaite")
+ anova(object = fm2.12, ddf = "Satterthwaite")
 
 library(multcomp)
 Contrasts1 <-

--- a/man/Examp2.6.1.Rd
+++ b/man/Examp2.6.1.Rd
@@ -21,11 +21,11 @@ linear models and generalized linear models.
  #                drug 0  0 dose 1 -1 drug*dose 0.5 -0.5  0.5 -0.5,
  #                drug 0  0 dose 0  0 drug*dose 0.5 -0.5 -0.5  0.5;
  # RUN;
- 
- library(lme4)
+
+ library(lmerTest)
  str(ex125)
  ex125$Region1 <- factor(ex125$Region)
- fm2.14 <- 
+ fm2.14 <-
   lmerTest::lmer(
          formula    = Pcv ~ dose*Drug + (1|Region/Drug)
        , data       = ex125
@@ -40,10 +40,10 @@ linear models and generalized linear models.
        , contrasts  = list(dose = "contr.SAS", Drug = "contr.SAS")
        , devFunOnly = FALSE
     #  , ...
-       )                       
+       )
  summary(fm2.14)
- lmerTest::anova(object = fm2.14, ddf = "Satterthwaite")
- 
+ anova(object = fm2.14, ddf = "Satterthwaite")
+
  library(multcomp)
  Contrasts3 <-
            matrix(c(
@@ -56,10 +56,13 @@ linear models and generalized linear models.
                  , rownames(summary(fm2.14)$coef)
                 )
                )
- 
+
  Contrasts3
  summary(glht(fm2.14, linfct=Contrasts3))
- 
+
+if(packageVersion("lmerTest") >= "3.0")
+   contest(fm2.14, Contrasts3, joint = FALSE)
+
 }
 \references{
 \enumerate{

--- a/man/Examp3.1.Rd
+++ b/man/Examp3.1.Rd
@@ -22,17 +22,17 @@ Examp3.1 is.
 # CONTRAST 'Berenil dif 2 doses' dose(drug) 1 -1 0;
 # CONTRAST 'Ber vs Sam at dose 1' drug 1 -1 dose(drug) 1 0 -l;
 # CONTRAST 'some difference' drug 1 -1 dose(drug) 0.5 0.5 -1,
-#           drug 0 0 dose(drug) 1 -1 0; 
+#           drug 0 0 dose(drug) 1 -1 0;
 # LSMEANS dose(drug);
 # RUN;
- 
+
  library(lmerTest)
  str(ex31)
  ex31$drug1 <- factor(ex31$drug)
  ex31$dose1 <- factor(ex31$dose)
  ex31$herd1 <- factor(ex31$herd)
- 
- fm3.1 <- 
+
+ fm3.1 <-
   lmerTest::lmer(
          formula    = PCV2 ~ drug1 + dose1:drug1 + (1|herd1:drug1)
        , data       = ex31
@@ -47,11 +47,11 @@ Examp3.1 is.
        , contrasts  = list(dose1 = "contr.SAS", drug1 = "contr.SAS")
        , devFunOnly = FALSE
     #  , ...
-       )                       
+       )
  summary(fm3.1)
- lmerTest::anova(object = fm3.1, ddf = "Satterthwaite")
- lmerTest::lsmeansLT(model = fm3.1, test.effs = "dose1:drug1")
- 
+ anova(object = fm3.1, ddf = "Satterthwaite")
+ lsmeansLT(model = fm3.1, test.effs = "dose1:drug1")
+
 #-------------------------------------------------------------
 ## Example 3.1 Model 2 p-84
 #-------------------------------------------------------------
@@ -60,14 +60,14 @@ Examp3.1 is.
 # MODEL PCV2=PCV1 drug dose(drug)/solution ddfm=satterth;
 # RANDOM herd(drug);
 # RUN;
- 
+
  library(lmerTest)
  str(ex31)
  ex31$drug1 <- factor(ex31$drug)
  ex31$dose1 <- factor(ex31$dose)
  ex31$herd1 <- factor(ex31$herd)
- 
- fm3.2 <- 
+
+ fm3.2 <-
   lmerTest::lmer(
          formula    = PCV2 ~ PCV1 + drug1 + dose1:drug1 + (1|herd1:drug1)
        , data       = ex31
@@ -82,11 +82,11 @@ Examp3.1 is.
        , contrasts  = list(dose1 = "contr.SAS", drug1 = "contr.SAS")
        , devFunOnly = FALSE
     #  , ...
-       )                       
+       )
  summary(fm3.2)
- lmerTest::anova(object = fm3.2, ddf = "Satterthwaite")
- lmerTest::lsmeansLT(model = fm3.2, test.effs = "herd1:drug1")
- 
+ anova(object = fm3.2, ddf = "Satterthwaite")
+ lsmeansLT(model = fm3.2, test.effs = "herd1:drug1")
+
 #-------------------------------------------------------------
 ## Example 3.1 Model 3 p-86
 #-------------------------------------------------------------
@@ -95,14 +95,14 @@ Examp3.1 is.
 # MODEL PCV2=drug dose(drug) PCV1*dose(drug)/solution ddfm=satterth;
 # RANDOM herd(drug);
 # RUN;
- 
+
  library(lmerTest)
  str(ex31)
  ex31$drug1 <- factor(ex31$drug)
  ex31$dose1 <- factor(ex31$dose)
  ex31$herd1 <- factor(ex31$herd)
- 
- fm3.3 <- 
+
+ fm3.3 <-
   lmerTest::lmer(
          formula    = PCV2 ~ drug1 + PCV1*dose1:drug1 + (1|herd1:drug1)
        , data       = ex31
@@ -117,10 +117,10 @@ Examp3.1 is.
        , contrasts  = list(dose1 = "contr.SAS", drug1 = "contr.SAS")
        , devFunOnly = FALSE
     #  , ...
-       )                       
+       )
  summary(fm3.3)
- lmerTest::anova(object = fm3.3, ddf = "Satterthwaite")
- lmerTest::lsmeansLT(model = fm3.3, test.effs = "dose1:drug1")
+ anova(object = fm3.3, ddf = "Satterthwaite")
+ lsmeansLT(model = fm3.3, test.effs = "dose1:drug1")
 }
 \references{
 \enumerate{

--- a/man/Examp3.2.Rd
+++ b/man/Examp3.2.Rd
@@ -18,13 +18,13 @@ linear models and generalized linear models.
 # RANDOM sire_id(breed)/SOLUTION;
 # LSMEANS breed/ADJUST = TUKEY;
 # RUN;
- 
+
  library(lmerTest)
  str(ex32)
  ex32$sire_id1 <- factor(ex32$sire_id)
  ex32$breed1   <- factor(ex32$breed)
- 
- fm3.4 <- 
+
+ fm3.4 <-
   lmerTest::lmer(
          formula    = Ww ~ sex + agew + breed1 + (1|sire_id1:breed1)
        , data       = ex32
@@ -39,10 +39,10 @@ linear models and generalized linear models.
        , contrasts  = list(sex = "contr.SAS", breed1 = "contr.SAS")
        , devFunOnly = FALSE
     #  , ...
-       )                       
+       )
  summary(fm3.4)
- lmerTest::anova(object = fm3.4, ddf = "Satterthwaite")
- lmerTest::lsmeansLT(model = fm3.4, test.effs = "breed1")
+ anova(object = fm3.4, ddf = "Satterthwaite")
+ lsmeansLT(model = fm3.4)
 }
 \references{
 \enumerate{

--- a/man/Examp3.3.Rd
+++ b/man/Examp3.3.Rd
@@ -21,8 +21,8 @@ linear models and generalized linear models.
  library(lme4)
  options(contrasts = c(factor = "contr.SAS", ordered = "contr.poly"))
  str(ex33)
-   
- fm3.5 <- 
+
+ fm3.5 <-
   lme4::lmer(
          formula    = PCV ~ breed + breed:time + (1|animal_id:breed)
        , data       = ex33
@@ -37,12 +37,12 @@ linear models and generalized linear models.
        , contrasts  = list(breed = "contr.SAS")
        , devFunOnly = FALSE
     #  , ...
-       )                       
+       )
  summary(fm3.5)
  anova(fm3.5)
- 
- 
- fm3.6 <- 
+
+ library(lmerTest)
+ fm3.6 <-
   lmerTest::lmer(
          formula    = PCV ~ breed + breed:time + (1|animal_id:breed)
        , data       = ex33
@@ -57,9 +57,9 @@ linear models and generalized linear models.
        , contrasts  = list(breed = "contr.SAS")
        , devFunOnly = FALSE
     #  , ...
-       )                       
+       )
  summary(fm3.6)
- lmerTest::anova(object = fm3.6, ddf = "Satterthwaite")
+ anova(object = fm3.6, ddf = "Satterthwaite")
 
 
 # PROC MIXED DATA=ex33;
@@ -69,8 +69,8 @@ linear models and generalized linear models.
 # RUN;
 
 
- library(nlme)  
- fm3.7 <- 
+ library(nlme)
+ fm3.7 <-
       nlme::gls(
             model       = PCV ~ breed + breed:time
           , data        = ex33
@@ -78,21 +78,21 @@ linear models and generalized linear models.
           , weights     = NULL
         # , subset      =
           , method      = "REML" # c("REML", "ML")
-          , na.action   = na.fail 
+          , na.action   = na.fail
           , control     = list()
           )
  summary(fm3.7)
  anova(fm3.7)
- 
- 
- 
+
+
+
 # PROC MIXED DATA=ex33;
 # CLASS breed animal_id;
 # MODEL pcv = time breed breed*time/SOLUTION;
 # RANDOM animal_id(breed)/SOLUTION;
 # RUN;
-     
- fm3.8 <- 
+
+ fm3.8 <-
   lme4::lmer(
          formula    = PCV ~ time + breed + breed:time + (1|animal_id:breed)
        , data       = ex33
@@ -111,8 +111,8 @@ linear models and generalized linear models.
  summary(fm3.8)
  anova(fm3.8)
 
-   
- fm3.9 <- 
+
+ fm3.9 <-
   lmerTest::lmer(
          formula    = PCV ~ time + breed + breed:time + (1|animal_id:breed)
        , data       = ex33
@@ -129,9 +129,9 @@ linear models and generalized linear models.
     #  , ...
        )
  summary(fm3.9)
- lmerTest::anova(object = fm3.9, ddf = "Satterthwaite", type = 3)
- 
- 
+ anova(object = fm3.9, ddf = "Satterthwaite", type = 3)
+
+
 # PROC MIXED DATA=ex33;
 # CLASS breed animal_id;
 # MODEL pcv = breed breed*time/SOLUTION;
@@ -139,8 +139,8 @@ linear models and generalized linear models.
 # RUN;
 
 
- library(nlme)  
- fm3.10 <- 
+ library(nlme)
+ fm3.10 <-
       nlme::gls(
             model       = PCV ~ breed + breed:time
           , data        = ex33
@@ -148,7 +148,7 @@ linear models and generalized linear models.
           , weights     = NULL
         # , subset      =
           , method      = "REML" # c("REML", "ML")
-          , na.action   = na.fail 
+          , na.action   = na.fail
           , control     = list()
           )
  summary(fm3.10)
@@ -162,7 +162,7 @@ linear models and generalized linear models.
 
 
  library(nlme)
-# fm3.11 <- 
+# fm3.11 <-
 #      nlme::gls(
 #            model       = PCV ~ breed + breed:time
 #          , data        = ex33
@@ -171,12 +171,12 @@ linear models and generalized linear models.
 #          , weights     = NULL
 #        # , subset      =
 #          , method      = "REML" # c("REML", "ML")
-#          , na.action   = na.fail 
+#          , na.action   = na.fail
 #          , control     = list()
 #          )
 # summary(fm3.11)
 # anova(fm3.11)
-      
+
 }
 \references{
 \enumerate{


### PR DESCRIPTION
Hi,

Please consider this PR which makes VetResearchLMM pass `R CMD check` without warnings or errors with new as well as old/current-CRAN versions of lmerTest. (I haven't checked for other lmerTest-unrelated issues...)

I noticed some problems with `lsmeansLT` in the _old_ version of lmerTest on rank-deficient fits, but setting `test.effs` as currently done appears to "mute" the problems. When the new version of lmerTest is on CRAN you may want to remove the `test.effs` arguments or change them to `which` _and_ add `lmerTest >= 3.0` in DESCRIPTION.

I also made a suggestion to use `lmerTest::contest` for a custom contrast in `R/Examp2.6.1.R` as an alternative to `glht`; note that `contest` provides the 'right' _t_-test instead of the asymptotic _z_-test that `glht` produces.

Cheers
Rune